### PR TITLE
add binary for aarch64-linux (rpi)

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -1777,7 +1777,8 @@ async function install() {
   const knownUnixlikePackages = {
     "aarch64-apple-darwin": "esbuild-darwin-arm64",
     "x86_64-apple-darwin": "esbuild-darwin-64",
-    "x86_64-unknown-linux-gnu": "esbuild-linux-64"
+    "x86_64-unknown-linux-gnu": "esbuild-linux-64",
+    "aarch64-unknown-linux-gnu": "esbuild-linux-arm64"
   };
   if (platformKey in knownWindowsPackages) {
     return await installFromNPM(knownWindowsPackages[platformKey], "esbuild.exe");


### PR DESCRIPTION
Add support for Raspberry Pi. Not sure if there's a reason that would contraindicate this, but there's no issues tab to discuss so submitting a PR seems like the next best option. Tested and works on rpi 4.