### PR TITLE
support npm_config_registry env variable

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -1712,7 +1712,8 @@ async function installFromNPM(name, subpath) {
     return finalPath;
   } catch (e) {
   }
-  const url = `https://registry.npmjs.org/${name}/-/${name.replace("@esbuild/", "")}-${version}.tgz`;
+  const npmRegistry = Deno.env.get("NPM_CONFIG_REGISTRY") || "https://registry.npmjs.org";
+  const url = `${npmRegistry}/${name}/-/${name.replace("@esbuild/", "")}-${version}.tgz`;
   const buffer = await fetch(url).then((r) => r.arrayBuffer());
   const executable = extractFileFromTarGzip(new Uint8Array(buffer), subpath);
   await Deno.mkdir(finalDir, {


### PR DESCRIPTION
I have to use an alternative NPM registry in my machine because my proxy blocks the public NPM's registry `https://registry.npmjs.org`, so I'm basically checking whether the `NPM_CONFIG_REGISTRY` env variable exists before fallbacking to the public one. In case anyone else needs support, here it is.